### PR TITLE
Switch piracy check to warning

### DIFF
--- a/IPA.Injector/AntiPiracy.cs
+++ b/IPA.Injector/AntiPiracy.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -15,7 +16,7 @@ namespace IPA.Injector
             "ReShadePreset.ini"
         };
 
-        public static bool IsInvalid(string path)
+        public static IEnumerable<string> IsInvalid(string path)
         {
             var dataPlugins = Path.Combine(GameVersionEarly.ResolveDataPath(path), "Plugins");
 
@@ -37,8 +38,10 @@ namespace IPA.Injector
 
             // To the guys that maintain a fork that removes this code: I would greatly appreciate if we could talk
             //   about this for a little bit. Please message me on Discord at DaNike#6223
-            return Directory.EnumerateFiles(path, "*").Any(IsInvalidFile) ||
-                   Directory.EnumerateFiles(dataPlugins, "*", SearchOption.AllDirectories).Any(IsInvalidFile);
+            return Directory.EnumerateFiles(path, "*")
+                .Concat(Directory.EnumerateFiles(dataPlugins, "*", SearchOption.AllDirectories))
+                .Where(IsInvalidFile)
+                .Select(file => file.Substring(path.Length + 1));
         }
 
         private static bool IsInvalidFile(string filePath)

--- a/IPA.Injector/Injector.cs
+++ b/IPA.Injector/Injector.cs
@@ -10,6 +10,7 @@ using Mono.Cecil.Cil;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -55,11 +56,10 @@ namespace IPA.Injector
 
                 Default.Debug("Initializing logger");
 
-                if (AntiPiracy.IsInvalid(Environment.CurrentDirectory))
+                var invalidFiles = AntiPiracy.IsInvalid(Environment.CurrentDirectory).ToList();
+                if (invalidFiles.Any())
                 {
-                    Default.Error("Invalid installation; please buy the game to run BSIPA.");
-
-                    return;
+                    Default.Warn($"Invalid installation; Unknown files: {string.Join(", ", invalidFiles)}");
                 }
 
                 EnsureDirectories();


### PR DESCRIPTION
The current check is a joke.

The repo is open source and there are already [multiple](https://github.com/aloki/BeatSaber-IPA-Reloaded) [forks](https://github.com/FroggMaster/BeatSaber-IPA-Reloaded-ArrPatch) with the code removed. The second has an automatic script to merge in changes made here. I'm happy to add to that list if you want.

You already have [open issues](https://github.com/nike4613/BeatSaber-IPA-Reloaded/issues/112) with users using legitimate tools and being blocked. Getting in the way will only push people to use forks of this repo and give you less control.

Furthermore you've gotten plenty of pushback from modders who don't want this either and you seem unwilling to listen.

One of two things is going to happen:
- This check is going to be changed
- People will use a different fork of BISPA

This PR removes the early return and simply prints the list of "invalid" files. Supports can decide if the files are obviously from piracy or not and I can continue to launch the game I have bought twice legitimately without being told I'm not allowed to put files in the game directory.